### PR TITLE
The `runtime_rank` was changed to `runtime_percentile` in LeetCode API

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -295,12 +295,11 @@ def _check_result(submission_id):
         result['answer'] = _split(r.get('code_output', ''))
         result['expected_answer'] = _split(r.get('expected_output', ''))
         result['stdout'] = _split(r.get('std_output', ''))
-        subm = get_submission(submission_id)
-        result['runtime_rank'] = subm['runtime_rank']
+        result['runtime_percentile'] = r.get('runtime_percentile', '')
     else:
         result['stdout'] = r.get('code_output', [])
         result['expected_answer'] = []
-        result['runtime_rank'] = 'N/A'
+        result['runtime_percentile'] = r.get('runtime_percentile', '')
     return result
 
 
@@ -498,7 +497,7 @@ def get_submission(sid):
         accum += frequency
         if my_runtime >= int(runtime):
             break
-    submission['runtime_rank'] = '{:.1f}%'.format(accum)
+    submission['runtime_percentile'] = '{:.1f}%'.format(accum)
     return submission
 
 

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -419,9 +419,13 @@ function! leetcode#FormatResult(result_)
                 \ '## State',
                 \ '  - '.result['state'],
                 \ '## Runtime',
-                \ '  - '.result['runtime'],
-                \ '## Runtime Rank',
-                \ printf('  - Faster than %f%% submissions', result['runtime_percentile'])]
+                \ '  - '.result['runtime']]
+    if string(result['runtime_percentile'])
+        call extend(output, [
+                    \ '## Runtime Rank',
+                    \ printf('  - Faster than %f%% submissions', result['runtime_percentile'])
+                    \ ])
+    endif
 
     if result['total'] > 0
         call extend(output, [

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -421,7 +421,7 @@ function! leetcode#FormatResult(result_)
                 \ '## Runtime',
                 \ '  - '.result['runtime'],
                 \ '## Runtime Rank',
-                \ '  - Faster than '.result['runtime_rank'].' submissions']
+                \ printf('  - Faster than %f%% submissions', result['runtime_percentile'])]
 
     if result['total'] > 0
         call extend(output, [
@@ -665,7 +665,7 @@ function! leetcode#ViewSubmission()
     " show the submission description as comments
     let desc = leetcode#FormatResult(subm)
     call extend(desc, ['', '## Runtime Rank',
-                \ '  - Faster than '.subm['runtime_rank'].' submissions'])
+                \ printf('  - Faster than %f%% submissions', subm['runtime_percentile'])]
     let filetype = subm['filetype']
     let output = [leetcode#CommentStart(filetype, 'Submission '.id),
                 \ leetcode#CommentLine(filetype, '')]

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -439,9 +439,6 @@ function! leetcode#FormatResult(result_)
     call extend(output, leetcode#MultiLineIfExists('Error', result['error'], 2))
     call extend(output, leetcode#MultiLineIfExists('Standard Output', result['stdout'], 2))
 
-    if len(result['testcase']) || len(result['answer']) || len(result['expected_answer'])
-        call add(output, '## Failed Test Case')
-    endif
     call extend(output, leetcode#MultiLineIfExists('Input', result['testcase'], 3))
     call extend(output, leetcode#MultiLineIfExists('Actual Answer', result['answer'], 3))
     call extend(output, leetcode#MultiLineIfExists('Expected Answer', result['expected_answer'], 3))


### PR DESCRIPTION
Hi, ianding1!

I am using your leetcode vim plugin. (Thank you!)

However, there was a problem with the `runtime_rank` when submitting the code. This is because the leetcode API results was changed.

The fixes are as follows.

1. `runtime_rank` is changed to` runtime_percentile` in code.
2. `runtime_percentile` is showed only when submitting.
3. Removed 'Failed Test case' header in result of test. Because the conditions for printing the header is invalid now.

You can check the changes by installing the plugin from my forked repository.

```
# Install
Plug 'devinjeon/leetcode.vim'

# Check the changes
:LeetCodeTest
:LeetCodeSubmit
```

+ Cute animal picture.

![image](https://user-images.githubusercontent.com/13311279/54442073-4f66c800-4781-11e9-9191-97658fe3e2b5.png)