### PR TITLE
Add leetcode china support

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -18,6 +18,7 @@ except ImportError:
 
 
 LC_BASE = ''
+LC_CSRF = ''
 LC_LOGIN = ''
 LC_GRAPHQL = ''
 LC_CATEGORY_PROBLEMS = ''
@@ -52,6 +53,7 @@ def enable_logging():
 
 def switch_china(is_china):
     global LC_BASE
+    global LC_CSRF
     global LC_LOGIN
     global LC_GRAPHQL
     global LC_CATEGORY_PROBLEMS
@@ -66,6 +68,7 @@ def switch_china(is_china):
         LC_BASE = 'https://leetcode-cn.com'
     else:
         LC_BASE = 'https://leetcode.com'
+    LC_CSRF = LC_BASE + '/ensure_csrf/'
     LC_LOGIN = LC_BASE + '/accounts/login/'
     LC_GRAPHQL = LC_BASE + '/graphql'
     LC_CATEGORY_PROBLEMS = LC_BASE + '/api/problems/{category}'
@@ -158,9 +161,12 @@ def is_login():
 def signin(username, password):
     global session
     session = requests.Session()
-    res = session.get(LC_LOGIN)
+    if LC_BASE.find("cn"):
+        res = session.get(LC_CSRF)
+    else:
+        res = session.get(LC_LOGIN)
     if res.status_code != 200:
-        _echoerr('cannot open ' + LC_LOGIN)
+        _echoerr('cannot open ' + LC_BASE)
         return False
 
     headers = {'Origin': LC_BASE,

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -17,17 +17,17 @@ except ImportError:
     vim = None
 
 
-LC_BASE = 'https://leetcode.com'
-LC_LOGIN = 'https://leetcode.com/accounts/login/'
-LC_GRAPHQL = 'https://leetcode.com/graphql'
-LC_CATEGORY_PROBLEMS = 'https://leetcode.com/api/problems/{category}'
-LC_PROBLEM = 'https://leetcode.com/problems/{slug}/description'
-LC_TEST = 'https://leetcode.com/problems/{slug}/interpret_solution/'
-LC_SUBMIT = 'https://leetcode.com/problems/{slug}/submit/'
-LC_SUBMISSIONS = 'https://leetcode.com/api/submissions/{slug}'
-LC_SUBMISSION = 'https://leetcode.com/submissions/detail/{submission}/'
-LC_CHECK = 'https://leetcode.com/submissions/detail/{submission}/check/'
-LC_PROBLEM_SET_ALL = 'https://leetcode.com/problemset/all/'
+LC_BASE = ''
+LC_LOGIN = ''
+LC_GRAPHQL = ''
+LC_CATEGORY_PROBLEMS = ''
+LC_PROBLEM = ''
+LC_TEST = ''
+LC_SUBMIT = ''
+LC_SUBMISSIONS = ''
+LC_SUBMISSION = ''
+LC_CHECK = ''
+LC_PROBLEM_SET_ALL = ''
 
 
 session = None
@@ -50,6 +50,32 @@ def enable_logging():
     log.addHandler(out_hdlr)
     log.setLevel(logging.INFO)
 
+def switch_china(is_china):
+    global LC_BASE
+    global LC_LOGIN
+    global LC_GRAPHQL
+    global LC_CATEGORY_PROBLEMS
+    global LC_PROBLEM
+    global LC_TEST
+    global LC_SUBMIT
+    global LC_SUBMISSIONS
+    global LC_SUBMISSION
+    global LC_CHECK
+    global LC_PROBLEM_SET_ALL
+    if is_china == 1:
+        LC_BASE = 'https://leetcode-cn.com'
+    else:
+        LC_BASE = 'https://leetcode.com'
+    LC_LOGIN = LC_BASE + '/accounts/login/'
+    LC_GRAPHQL = LC_BASE + '/graphql'
+    LC_CATEGORY_PROBLEMS = LC_BASE + '/api/problems/{category}'
+    LC_PROBLEM = LC_BASE + '/problems/{slug}/description'
+    LC_TEST = LC_BASE + '/problems/{slug}/interpret_solution/'
+    LC_SUBMIT = LC_BASE + '/problems/{slug}/submit/'
+    LC_SUBMISSIONS = LC_BASE + '/api/submissions/{slug}'
+    LC_SUBMISSION = LC_BASE + '/submissions/detail/{submission}/'
+    LC_CHECK = LC_BASE + '/submissions/detail/{submission}/check/'
+    LC_PROBLEM_SET_ALL = LC_BASE + '/problemset/all/'
 
 def _make_headers():
     assert is_login()

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -18,7 +18,7 @@ except ImportError:
     vim = None
 
 
-LC_BASE = os.environ["LEETCODE_BASE_URL"]
+LC_BASE = os.environ['LEETCODE_BASE_URL']
 LC_CSRF = LC_BASE + '/ensure_csrf/'
 LC_LOGIN = LC_BASE + '/accounts/login/'
 LC_GRAPHQL = LC_BASE + '/graphql'
@@ -133,7 +133,7 @@ def is_login():
 def signin(username, password):
     global session
     session = requests.Session()
-    if LC_BASE.find("cn"):
+    if 'cn' in LC_BASE:
         res = session.get(LC_CSRF)
     else:
         res = session.get(LC_LOGIN)

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import time
+import os
 from threading import Semaphore, Thread, current_thread
 
 try:
@@ -17,19 +18,18 @@ except ImportError:
     vim = None
 
 
-LC_BASE = ''
-LC_CSRF = ''
-LC_LOGIN = ''
-LC_GRAPHQL = ''
-LC_CATEGORY_PROBLEMS = ''
-LC_PROBLEM = ''
-LC_TEST = ''
-LC_SUBMIT = ''
-LC_SUBMISSIONS = ''
-LC_SUBMISSION = ''
-LC_CHECK = ''
-LC_PROBLEM_SET_ALL = ''
-
+LC_BASE = os.environ["LEETCODE_BASE_URL"]
+LC_CSRF = LC_BASE + '/ensure_csrf/'
+LC_LOGIN = LC_BASE + '/accounts/login/'
+LC_GRAPHQL = LC_BASE + '/graphql'
+LC_CATEGORY_PROBLEMS = LC_BASE + '/api/problems/{category}'
+LC_PROBLEM = LC_BASE + '/problems/{slug}/description'
+LC_TEST = LC_BASE + '/problems/{slug}/interpret_solution/'
+LC_SUBMIT = LC_BASE + '/problems/{slug}/submit/'
+LC_SUBMISSIONS = LC_BASE + '/api/submissions/{slug}'
+LC_SUBMISSION = LC_BASE + '/submissions/detail/{submission}/'
+LC_CHECK = LC_BASE + '/submissions/detail/{submission}/check/'
+LC_PROBLEM_SET_ALL = LC_BASE + '/problemset/all/'
 
 session = None
 task_running = False
@@ -51,34 +51,6 @@ def enable_logging():
     log.addHandler(out_hdlr)
     log.setLevel(logging.INFO)
 
-def switch_china(is_china):
-    global LC_BASE
-    global LC_CSRF
-    global LC_LOGIN
-    global LC_GRAPHQL
-    global LC_CATEGORY_PROBLEMS
-    global LC_PROBLEM
-    global LC_TEST
-    global LC_SUBMIT
-    global LC_SUBMISSIONS
-    global LC_SUBMISSION
-    global LC_CHECK
-    global LC_PROBLEM_SET_ALL
-    if is_china == 1:
-        LC_BASE = 'https://leetcode-cn.com'
-    else:
-        LC_BASE = 'https://leetcode.com'
-    LC_CSRF = LC_BASE + '/ensure_csrf/'
-    LC_LOGIN = LC_BASE + '/accounts/login/'
-    LC_GRAPHQL = LC_BASE + '/graphql'
-    LC_CATEGORY_PROBLEMS = LC_BASE + '/api/problems/{category}'
-    LC_PROBLEM = LC_BASE + '/problems/{slug}/description'
-    LC_TEST = LC_BASE + '/problems/{slug}/interpret_solution/'
-    LC_SUBMIT = LC_BASE + '/problems/{slug}/submit/'
-    LC_SUBMISSIONS = LC_BASE + '/api/submissions/{slug}'
-    LC_SUBMISSION = LC_BASE + '/submissions/detail/{submission}/'
-    LC_CHECK = LC_BASE + '/submissions/detail/{submission}/check/'
-    LC_PROBLEM_SET_ALL = LC_BASE + '/problemset/all/'
 
 def _make_headers():
     assert is_login()

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -3,7 +3,7 @@
 let s:current_dir = expand("<sfile>:p:h")
 
 python3 <<EOF
-import os.path
+import os
 import vim
 
 plugin_dir = vim.eval('s:current_dir')
@@ -15,6 +15,11 @@ if plugin_dir not in sys.path:
 if thirdparty_dir not in sys.path:
   sys.path.append(thirdparty_dir)
 
+if vim.eval('g:leetcode_china'):
+    os.environ["LEETCODE_BASE_URL"] = "https://leetcode-cn.com"
+else:
+    os.environ["LEETCODE_BASE_URL"] = "https://leetcode.com"
+
 import leetcode
 EOF
 
@@ -22,12 +27,6 @@ let s:inited = py3eval('leetcode.inited')
 
 if g:leetcode_debug
     python3 leetcode.enable_logging()
-endif
-
-if g:leetcode_china
-    python3 leetcode.switch_china(1)
-else
-    python3 leetcode.switch_china(0)
 endif
 
 function! leetcode#SignIn(ask)

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -15,10 +15,10 @@ if plugin_dir not in sys.path:
 if thirdparty_dir not in sys.path:
   sys.path.append(thirdparty_dir)
 
-if vim.eval('g:leetcode_china'):
-    os.environ["LEETCODE_BASE_URL"] = "https://leetcode-cn.com"
+if int(vim.eval('g:leetcode_china')):
+    os.environ['LEETCODE_BASE_URL'] = 'https://leetcode-cn.com'
 else:
-    os.environ["LEETCODE_BASE_URL"] = "https://leetcode.com"
+    os.environ['LEETCODE_BASE_URL'] = 'https://leetcode.com'
 
 import leetcode
 EOF

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -24,6 +24,12 @@ if g:leetcode_debug
     python3 leetcode.enable_logging()
 endif
 
+if g:leetcode_china
+    python3 leetcode.switch_china(1)
+else
+    python3 leetcode.switch_china(0)
+endif
+
 function! leetcode#SignIn(ask)
     if !s:inited
         return v:false

--- a/plugin/leetcode.vim
+++ b/plugin/leetcode.vim
@@ -1,5 +1,9 @@
 " vim: sts=4 sw=4 expandtab
 
+if !exists('g:leetcode_china')
+    let g:leetcode_china = 0
+endif
+
 if !exists('g:leetcode_username')
     let g:leetcode_username = ''
 endif


### PR DESCRIPTION
In China, we use `leetcode-cn.com` instead of `leetcode.com`, so I add a vim config `leetcode_china` which can switch to China site. And I find `leetcode-cn.com` use `leetcode-cn.com/ensure_csrf/` to get csrf.

It's my first time to use `Python`, so it may be ugly... And sorry for my bad English...