### PR TITLE
Minor fix for the first-time leetcode list loading;

### DIFF
--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -1,5 +1,8 @@
 " vim: sts=4 sw=4 expandtab
-
+if exists("g:leetcode_list_buffer_exists")
+    echo 'buffer exists'
+    finish
+endif
 let s:current_dir = expand("<sfile>:p:h")
 
 python3 <<EOF
@@ -361,11 +364,10 @@ function! s:ListProblemsOfCompany(company_slug, refresh) abort
 endfunction
 
 function! leetcode#ListProblems(refresh) abort
+    let buf_name = 'leetcode:///problems/all'
     if s:CheckSignIn() == v:false
         return
     endif
-
-    let buf_name = 'leetcode:///problems/all'
     if buflisted(buf_name)
         execute bufnr(buf_name) . 'buffer'
         let saved_view = winsaveview()
@@ -378,6 +380,7 @@ function! leetcode#ListProblems(refresh) abort
         setlocal modifiable
         silent! normal! ggdG
     else
+        let g:leetcode_list_buffer_exists=1
         execute 'rightbelow new ' . buf_name
         call s:SetupProblemListBuffer()
         let b:leetcode_buffer_type = 'all'


### PR DESCRIPTION
Hi ianding1!

Idk if you can reproduce, but whenever I call ":LeetCodeList" for the
first time, what happens is:
- the autoload loads the lettcode.vim from the autoload folder
- the leetcode#ListProblems creates a new buffer;
- because the buffer is of no type (i might be saying dumb things here..)
  the autoload attempts to load the function again, which it fails to
  do because the function is in the middle of the rest call;
- nvim displays a message
`Signed in.
Error detected while processing /Users/atuzhikov/.vim/plugged/leetcode.vim/autoload/leetcode.vim:
line  425:
E127: Cannot redefine function leetcode#ListProblems: It is in use`
which is ok, but fairly annoying.

The proposed change is to check whether the list buffer has already been
loaded, and if yes - no need to redefine the functions.

Thank you for considering the pr, and once again - thank you for the plugin,
it saves me from a lot of going back and forth to the web page;

Cheers!
