### PR TITLE
Changed the index for the slug in file_name, fix for #31

### DIFF
--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -786,7 +786,7 @@ function! leetcode#TestSolution() abort
         return
     endif
 
-    let slug = split(file_name, '\.')[0]
+    let slug = split(file_name, '\.')[1]
     let filetype = s:GuessFileType()
 
     if exists('b:leetcode_problem')


### PR DESCRIPTION
Filenames are named using `printf('%s.%s.%s', problem_id, s:SlugToFileName(problem_slug), problem_ext)`, but TestSolution() expected the problem_slug to be the zeroth index. Simply changed index from 0 to 1.