### PR TITLE
Fix for stdout format

### DIFF
--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -971,12 +971,16 @@ function! s:FormatResult(result_) abort
     endif
 
     call extend(output, s:FormatSection('Error', result['error'], 2))
-    call extend(output, s:FormatSection('Standard Output', result['stdout'], 2))
 
     call extend(output, s:FormatSection('Input', result['testcase'], 3))
     call extend(output, s:FormatSection('Actual Answer', result['answer'], 3))
     call extend(output, s:FormatSection('Expected Answer',
                 \ result['expected_answer'], 3))
+    call extend(output, [
+                    \ '### Stdout',
+                    \ '    ' . result['stdout'],
+                    \ '',
+                    \ ])
     return output
 endfunction
 


### PR DESCRIPTION
About #35,
I found it is because stdout format is string. e.g '['1','2']'

could you review it?
