### PR TITLE
Add support for splitting description and code template in separate splits. 

### DIFF
--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -715,6 +715,8 @@ function! leetcode#ResetSolution(with_latest_submission) abort
 
     call append('$', output)
     setlocal nomodifiable
+    setlocal buftype=nofile
+    setlocal nospell
 
     silent! normal! ggdd
     execute 'wincmd j'

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -509,7 +509,7 @@ function! s:HandleProblemListCR() abort
         let problem = s:GetProblem(problem_id)
         let problem_slug = problem['slug']
         let problem_ext = s:SolutionFileExt(g:leetcode_solution_filetype)
-        let problem_file_name = printf('%s.%s.%s', problem_id,
+        let problem_file_name = printf('[DESC] %s.%s.%s', problem_id,
                     \  s:SlugToFileName(problem_slug),
                     \ problem_ext)
 
@@ -702,8 +702,18 @@ function! leetcode#ResetSolution(with_latest_submission) abort
     endfor
     call add(output, s:CommentEnd(filetype))
     call append('$', output)
-
     silent! normal! gggqG
+
+    let problem_ext = s:SolutionFileExt(g:leetcode_solution_filetype)
+    " TODO avoid recalculation of problem_ext twice
+    let problem_new_file_name = printf('%s.%s.%s', problem['id'], problem_slug, problem_ext)
+    if buflisted(problem_file_name)
+        execute bufnr(problem_new_file_name) . 'buffer'
+        return
+    endif
+
+    execute 'rightbelow new ' . problem_new_file_name
+
 
     call append('$', code)
 

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -509,7 +509,7 @@ function! s:HandleProblemListCR() abort
         let problem = s:GetProblem(problem_id)
         let problem_slug = problem['slug']
         let problem_ext = s:SolutionFileExt(g:leetcode_solution_filetype)
-        let problem_file_name = printf('[DESC] %s.%s.%s', problem_id,
+        let problem_file_name = printf('%s.%s.%s', problem_id,
                     \  s:SlugToFileName(problem_slug),
                     \ problem_ext)
 
@@ -701,23 +701,23 @@ function! leetcode#ResetSolution(with_latest_submission) abort
         call add(output, s:CommentLine(filetype, line))
     endfor
     call add(output, s:CommentEnd(filetype))
-    call append('$', output)
+    call append('$', code)
     silent! normal! gggqG
 
-    let problem_ext = s:SolutionFileExt(g:leetcode_solution_filetype)
-    " TODO avoid recalculation of problem_ext twice
-    let problem_new_file_name = printf('%s.%s.%s', problem['id'], problem_slug, problem_ext)
-    if buflisted(problem_file_name)
-        execute bufnr(problem_new_file_name) . 'buffer'
+    let problem_desc_file_name = printf('[DESCRIPTION] %s.%s', problem['id'], problem_slug)
+    if buflisted(problem_desc_file_name)
+        execute bufnr(problem_desc_file_name) . 'buffer'
         return
     endif
 
-    execute 'rightbelow new ' . problem_new_file_name
+    execute 'leftabove '. len(output). 'new ' . problem_desc_file_name
 
 
-    call append('$', code)
+    call append('$', output)
+    setlocal nomodifiable
 
     silent! normal! ggdd
+    execute 'wincmd j'
 endfunction
 
 function! s:CommentStart(filetype, title) abort


### PR DESCRIPTION
I have implemented a basic splitting functionality where the problem description is opened in a new split above the code template split with size equal to the length of the problem description. Some buffer local options are set accordingly.

This resolves #28 

Currently, the problem description split is of type `nofile`, therefore cannot be saved.


Another way of adding this feature would be to remove the `_remove_description` method before sending user code to leetcode. This way, leetcode will return appropriate line numbers. I am fine with either.