### PR TITLE
Change 'submit' vs 'run code' response parsing conditional from judge_type to submission_id startswith 'runcode_'

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -348,12 +348,12 @@ def _check_result(submission_id):
 
     # the keys differs between the result of testing the code and submitting it
     # for submission judge_type is 'large', and for testing judge_type does not exist
-    if r.get('judge_type') != 'large':
-        result['answer'] = _split(r.get('code_output', ''))
-        result['expected_answer'] = _split(r.get('expected_output', ''))
-        result['stdout'] = _split(r.get('std_output', ''))
-        result['runtime_percentile'] = r.get('runtime_percentile', '')
-    else:
+    # Note: 
+    #   As of October 09 2020, 'judge_type' is not provided in response, 
+    #   however we can use submission_id's value to decide output formatting
+    #   'Run code' Example submission_id: "runcode_1602277499.4352891_sYj3Jte5Lb"   
+    #   'Submit' Example submission_id: "406680787" 
+    if r.get('submission_id').startswith('runcode_'):
         # Test states cannot distinguish accepted answers from wrong answers.
         if result['state'] == 'Accepted':
             result['state'] = 'Finished'
@@ -361,6 +361,11 @@ def _check_result(submission_id):
         result['expected_answer'] = []
         result['runtime_percentile'] = r.get('runtime_percentile', '')
         result['expected_answer'] = r.get('expected_code_answer', [])
+    else:
+        result['answer'] = _split(r.get('code_output', ''))
+        result['expected_answer'] = _split(r.get('expected_output', ''))
+        result['stdout'] = _split(r.get('std_output', ''))
+        result['runtime_percentile'] = r.get('runtime_percentile', '')
     return result
 
 

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -338,6 +338,7 @@ def _check_result(submission_id):
 
     result = {
         'answer': r.get('code_answer', []),
+        'code_output': r.get('code_output'),
         'runtime': r['status_runtime'],
         'state': _status_to_name(r['status_code']),
         'testcase': _split(r.get('input', r.get('last_testcase', ''))),

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -338,7 +338,6 @@ def _check_result(submission_id):
 
     result = {
         'answer': r.get('code_answer', []),
-        'code_output': r.get('code_output'),
         'runtime': r['status_runtime'],
         'state': _status_to_name(r['status_code']),
         'testcase': _split(r.get('input', r.get('last_testcase', ''))),

--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -348,7 +348,7 @@ def _check_result(submission_id):
 
     # the keys differs between the result of testing the code and submitting it
     # for submission judge_type is 'large', and for testing judge_type does not exist
-    if r.get('judge_type') == 'large':
+    if r.get('judge_type') != 'large':
         result['answer'] = _split(r.get('code_output', ''))
         result['expected_answer'] = _split(r.get('expected_output', ''))
         result['stdout'] = _split(r.get('std_output', ''))

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -1000,8 +1000,7 @@ function! s:FormatResult(result_) abort
     endif
 
     call extend(output, s:FormatSection('Error', result['error'], 2))
-    call extend(output, s:FormatSection('Output', result['stdout'], 2))
-    call extend(output, s:FormatSection('Standard Output', result['code_output'], 2))
+    call extend(output, s:FormatSection('Standard Output', result['stdout'], 2))
 
     call extend(output, s:FormatSection('Input', result['testcase'], 3))
     call extend(output, s:FormatSection('Actual Answer', result['answer'], 3))

--- a/autoload/leetcode.vim
+++ b/autoload/leetcode.vim
@@ -1000,7 +1000,8 @@ function! s:FormatResult(result_) abort
     endif
 
     call extend(output, s:FormatSection('Error', result['error'], 2))
-    call extend(output, s:FormatSection('Standard Output', result['stdout'], 2))
+    call extend(output, s:FormatSection('Output', result['stdout'], 2))
+    call extend(output, s:FormatSection('Standard Output', result['code_output'], 2))
 
     call extend(output, s:FormatSection('Input', result['testcase'], 3))
     call extend(output, s:FormatSection('Actual Answer', result['answer'], 3))


### PR DESCRIPTION
I am unsure if this was intended behavior, but I am unable to currently run 'LeetCodeTest' and get a 'Run Code' / 'test' submission. I am only able to run 'LeetCodeSubmit' and get back some output. After a while, I noticed the output was missing std_output for debugging. I found in the code that we chose to branch on judge_type == 'large'... I am thinking it would be better to branch on submission_id since they are uniquely formatted between Submit and Run Code.

Maybe someone can help me get my LeetCodeTest to run correctly?

INPUT:
```
impl Solution {
    pub fn two_sum(nums: Vec<i32>, target: i32) -> Vec<i32> {
        
        println!("nums: {:?}", nums);
        println!("target: {}", target);
        for x in 0..nums.len() {
            println!("{}", x)
        }

        vec![0, 23333]
    }
}
```

Example output after proposed change of LeetCodeSubmit
```
# Two Sum

## State
  - Wrong Answer

## Runtime
  - N/A

## Test Cases
  - Passed: 0
  - Total:  29
  - WARNING: some test cases failed

## Standard Output
    nums: [2, 7, 11, 15]
    target: 9
    0
    1
    2
    3
    

### Input
    [2,7,11,15]
    9

### Actual Answer
    [0,23333]

### Expected Answer
    [0,1]


```