### PR TITLE
Add request header to avoid 403 from https://leetcode.com/api/progres…

### DIFF
--- a/autoload/leetcode.py
+++ b/autoload/leetcode.py
@@ -71,6 +71,7 @@ def _make_headers():
     headers = {'Origin': LC_BASE,
                'Referer': LC_BASE,
                'X-Requested-With': 'XMLHttpRequest',
+               'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0',
                'X-CSRFToken': session.cookies.get('csrftoken', '')}
     return headers
 


### PR DESCRIPTION
To solve issue about firefox login cookies on OSX.

cannot get the progress
cannot get progress. Please relogin in your browser.
![image](https://github.com/ianding1/leetcode.vim/assets/12585876/e41a288f-22d0-4a05-b40a-4c9d33d01e37)
